### PR TITLE
Fix speed pulse output

### DIFF
--- a/TeensyModules/V2.5/Firmware/Autosteer_gps_teensy_v5/Autosteer_gps_teensy_v5.ino
+++ b/TeensyModules/V2.5/Firmware/Autosteer_gps_teensy_v5/Autosteer_gps_teensy_v5.ino
@@ -36,7 +36,7 @@ HardwareSerial* SerialGPSTmp = NULL;
 
 const int32_t baudAOG = 115200;
 const int32_t baudGPS = 460800;
-const int32_t baudRTK = 9600;
+const int32_t baudRTK = 115200;     // most are using Xbee radios with default of 115200
 
 // Baudrates for detecting UBX receiver
 uint32_t baudrates[]
@@ -120,7 +120,7 @@ byte CK_B = 0;
 int relposnedByteCount = 0;
 
 //Speed pulse output
-unsigned long prev_PWM_Millis = 0;
+elapsedMillis speedPulseUpdateTimer = 0;
 byte velocityPWM_Pin = 36;      // Velocity (MPH speed) PWM pin
 
 #include "zNMEAParser.h"


### PR DESCRIPTION
Fixed speed pulse output to turn off when gps speed is below 0.1 and when it has not been updated within 1000ms (ie UDP comms lost)
Also changed baudRTK to more common 115200.