### PR TITLE
fix ads wire calls

### DIFF
--- a/TeensyModules/V2.5/Firmware/Autosteer_gps_teensy_v2_5/zADS1115.cpp
+++ b/TeensyModules/V2.5/Firmware/Autosteer_gps_teensy_v2_5/zADS1115.cpp
@@ -15,8 +15,8 @@
 */
 /**************************************************************************/
 ADS1115_lite::ADS1115_lite(uint8_t i2cAddress) {
-	Wire1.end();
-	Wire1.begin();
+	//Wire1.end();
+	//Wire1.begin();
 	_i2cAddress = i2cAddress;
 	_gain = ADS1115_REG_CONFIG_PGA_2_048V; /* +/- 6.144V range (limited to VDD +0.3V max!) */
 	_mux = ADS1115_REG_CONFIG_MUX_DIFF_0_1; /* to default */

--- a/TeensyModules/V4.1/Firmware/Autosteer_gps_teensy_v4_1/zADS1115.cpp
+++ b/TeensyModules/V4.1/Firmware/Autosteer_gps_teensy_v4_1/zADS1115.cpp
@@ -15,8 +15,8 @@
 */
 /**************************************************************************/
 ADS1115_lite::ADS1115_lite(uint8_t i2cAddress) {
-	Wire1.end();
-	Wire1.begin();
+	//Wire1.end();
+	//Wire1.begin();
 	_i2cAddress = i2cAddress;
 	_gain = ADS1115_REG_CONFIG_PGA_2_048V; /* +/- 6.144V range (limited to VDD +0.3V max!) */
 	_mux = ADS1115_REG_CONFIG_MUX_DIFF_0_1; /* to default */


### PR DESCRIPTION
Removed ads Wire1 calls that cause Teensy boot loops if using Teensyduino 1.58+
https://discourse.agopengps.com/t/teensy-disconnecting/12932/10